### PR TITLE
Add standardized CSV export and UI download

### DIFF
--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -10,11 +10,11 @@ import {
   extractTextFromPDF,
   legacyTransactionsToCanonical,
   parseStatementText,
-  transactionsToCSV,
   Transaction
 } from "@/lib/pdfParser";
 import { ingestWithDocumentAI } from "@/lib/ingestionClient";
-import type { CanonicalTransaction } from "@shared/transactions";
+import { toCSV } from "@shared/export/csv";
+import type { NormalizedTransaction } from "@shared/types";
 import { Download, FileText, Loader2 } from "lucide-react";
 import { useRef, useState } from "react";
 import { toast } from "sonner";

--- a/shared/export/csv.ts
+++ b/shared/export/csv.ts
@@ -18,11 +18,14 @@ export function toCSV(
 
   const rows = records.map(record => {
     const displayDate = formatDate(record.date ?? record.posted_date);
+    const payee = record.payee?.trim()
+      ? record.payee
+      : record.description ?? "";
 
     return [
       displayDate,
       record.description ?? "",
-      record.payee ?? record.description ?? "",
+      payee,
       formatAmount(record.debit),
       formatAmount(record.credit),
       formatAmount(record.balance),


### PR DESCRIPTION
## Summary
- Standardize CSV export formatting for normalized transactions, including BOM support, payee fallbacks, and memo sanitization
- Expand CSV export tests to cover debit/credit cases, metadata filtering, payee fallback, and empty exports
- Wire the ingestion UI export action to the shared CSV generator

## Testing
- pnpm test *(fails: vitest not installed in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69360fa4ac6c832f9791a3af2223d71f)