### PR TITLE
ISSUE #11 — ENV Diagnostics Badge (DocAI / Ingestion State)

### DIFF
--- a/client/src/components/ingestion/DebugPanel.tsx
+++ b/client/src/components/ingestion/DebugPanel.tsx
@@ -8,8 +8,14 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import type { CanonicalTransaction } from "@shared/transactions";
-import { RefreshCw } from "lucide-react";
+import { CheckCircle2, AlertTriangle, RefreshCw } from "lucide-react";
+import { useEffect, useState } from "react";
 
 export interface IngestionDebugData {
   source: "documentai" | "unavailable" | "error";
@@ -21,10 +27,17 @@ export interface DebugPanelProps {
   onRetry: () => void;
 }
 
+export interface EnvStatus {
+  docaiConfigured: boolean;
+  ingestMode: "docai" | "fallback";
+  lastChecked: string;
+}
+
 /**
  * Debug panel component for inspecting ingestion results and normalized transactions.
  * 
  * Displays:
+ * - Environment status badge (DocAI Enabled / No DocAI Keys)
  * - Source badge (DOC AI PATH / FALLBACK PATH)
  * - Preview table of first 10 normalized transactions
  * - Retry button to reset the pipeline
@@ -33,6 +46,27 @@ export interface DebugPanelProps {
  */
 export default function DebugPanel({ ingestionData, onRetry }: DebugPanelProps) {
   const { source, normalizedTransactions } = ingestionData;
+  const [envStatus, setEnvStatus] = useState<EnvStatus | null>(null);
+  const [isLoadingStatus, setIsLoadingStatus] = useState(true);
+  
+  // Fetch environment status on mount
+  useEffect(() => {
+    const fetchEnvStatus = async () => {
+      try {
+        const response = await fetch("/api/env/status");
+        if (response.ok) {
+          const data = await response.json();
+          setEnvStatus(data);
+        }
+      } catch (error) {
+        console.error("Failed to fetch env status", error);
+      } finally {
+        setIsLoadingStatus(false);
+      }
+    };
+    
+    fetchEnvStatus();
+  }, []);
   
   // Show first 10 transactions
   const previewTransactions = normalizedTransactions.slice(0, 10);
@@ -51,19 +85,60 @@ export default function DebugPanel({ ingestionData, onRetry }: DebugPanelProps) 
     ? "secondary" 
     : "destructive";
 
+  // Environment status badge
+  const envStatusBadge = envStatus ? (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Badge 
+          variant={envStatus.docaiConfigured ? "default" : "secondary"}
+          className="uppercase tracking-wide cursor-help"
+        >
+          {envStatus.docaiConfigured ? (
+            <>
+              <CheckCircle2 className="w-3 h-3 mr-1" />
+              DocAI Enabled
+            </>
+          ) : (
+            <>
+              <AlertTriangle className="w-3 h-3 mr-1" />
+              No DocAI Keys — Running Fallback
+            </>
+          )}
+        </Badge>
+      </TooltipTrigger>
+      <TooltipContent>
+        <div className="space-y-1">
+          <div className="font-semibold">Configuration Status</div>
+          <div>Mode: {envStatus.ingestMode}</div>
+          <div>DocAI Configured: {envStatus.docaiConfigured ? "Yes" : "No"}</div>
+          <div className="text-xs text-muted-foreground mt-1">
+            Last checked: {new Date(envStatus.lastChecked).toLocaleTimeString()}
+          </div>
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  ) : isLoadingStatus ? (
+    <Badge variant="outline" className="uppercase tracking-wide">
+      Loading...
+    </Badge>
+  ) : null;
+
   return (
     <div className="rounded-xl border border-dashed border-border/70 bg-card/50 p-4 space-y-4">
       <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-3 flex-wrap">
           <div>
             <div className="text-sm font-semibold text-foreground">Ingestion Debug Panel</div>
             <p className="text-xs text-muted-foreground mt-1">
               Raw normalized transactions and ingestion source for troubleshooting.
             </p>
           </div>
-          <Badge variant={sourceVariant} className="uppercase tracking-wide">
-            {sourceLabel}
-          </Badge>
+          <div className="flex items-center gap-2 flex-wrap">
+            {envStatusBadge}
+            <Badge variant={sourceVariant} className="uppercase tracking-wide">
+              {sourceLabel}
+            </Badge>
+          </div>
         </div>
         <Button 
           variant="outline" 

--- a/server/_core/env.ts
+++ b/server/_core/env.ts
@@ -15,6 +15,9 @@ export const ENV = {
   gcpInvoiceProcessorId: process.env.GCP_INVOICE_PROCESSOR_ID ?? "",
   gcpOcrProcessorId: process.env.GCP_OCR_PROCESSOR_ID ?? "",
   gcpCredentialsJson: process.env.GCP_DOCUMENTAI_CREDENTIALS ?? "",
+  enableDocAi: process.env.ENABLE_DOC_AI === "true",
+  gcpServiceAccountJson: process.env.GCP_SERVICE_ACCOUNT_JSON ?? "",
+  gcpServiceAccountPath: process.env.GCP_SERVICE_ACCOUNT_PATH ?? "",
 };
 
 export type DocumentAiProcessorType = "bank" | "invoice" | "ocr" | "form";
@@ -32,10 +35,10 @@ export interface DocumentAiConfig {
 
 export function getDocumentAiConfig(): DocumentAiConfig {
   const processors: Partial<Record<DocumentAiProcessorType, string>> = {
-    bank: ENV.docAiBankProcessorId || undefined,
-    invoice: ENV.docAiInvoiceProcessorId || undefined,
-    ocr: ENV.docAiOcrProcessorId || undefined,
-    form: ENV.docAiFormProcessorId || undefined,
+    bank: ENV.gcpBankProcessorId || undefined,
+    invoice: ENV.gcpInvoiceProcessorId || undefined,
+    ocr: ENV.gcpOcrProcessorId || undefined,
+    form: undefined, // Not currently configured
   };
 
   const credentials = loadServiceAccount();


### PR DESCRIPTION
## 🎯 Purpose

Visibly surface system configuration so misconfigurations don't go unnoticed. Add an environment diagnostics badge to the DebugPanel that shows DocAI configuration status.

## ✨ Changes

### Backend
- **Added `GET /api/env/status` endpoint** (`server/ingestRoutes.ts`):
  - Returns `docaiConfigured: boolean`
  - Returns `ingestMode: "docai" | "fallback"`
  - Returns `lastChecked: string` (ISO timestamp)
  - Uses `getDocumentAiConfig()` to check actual configuration state

- **Fixed `server/_core/env.ts`**:
  - Added `enableDocAi` property (checks `ENABLE_DOC_AI` env var)
  - Added `gcpServiceAccountJson` and `gcpServiceAccountPath` properties
  - Fixed processor ID references to use correct property names (`gcpBankProcessorId` instead of `docAiBankProcessorId`)

### Frontend
- **Extended `DebugPanel.tsx`**:
  - Fetches environment status from `/api/env/status` endpoint on mount
  - Displays environment status badge:
    - **"✔ DocAI Enabled"** (green/default variant) when configured
    - **"⚠ No DocAI Keys — Running Fallback"** (secondary variant) when not configured
  - Added tooltip showing:
    - Configuration status
    - Ingest mode (docai/fallback)
    - DocAI configured status
    - Last checked timestamp
  - Badge includes icons (CheckCircle2 for enabled, AlertTriangle for warning)

## 🔧 Features

- **Real-time Status**: Fetches actual backend configuration, not inferred
- **Visual Indicators**: Color-coded badges with icons
- **Informative Tooltip**: Hover shows detailed configuration info
- **Error Handling**: Gracefully handles fetch failures

## ✔ Acceptance Criteria

- ✅ UI exposes correct status from backend endpoint
- ✅ Badge shows warning when keys are missing
- ✅ DebugPanel pulls from endpoint (not inferred guesswork)
- ✅ Badge color changes based on configuration state
- ✅ Tooltip provides additional details

## 🧪 Testing

To test:
1. Set `VITE_DEBUG_VIEW=true` in your `.env` file
2. Upload a bank statement PDF
3. Verify debug panel appears with environment status badge
4. Test with `ENABLE_DOC_AI=true` (should show "✔ DocAI Enabled")
5. Test with `ENABLE_DOC_AI=false` or missing keys (should show "⚠ No DocAI Keys — Running Fallback")
6. Hover over badge to see tooltip with details

Fixes #11