### PR TITLE
Align ingestion result mapping with telemetry and fallback data

### DIFF
--- a/client/src/components/ingestion/DebugPanel.tsx
+++ b/client/src/components/ingestion/DebugPanel.tsx
@@ -8,12 +8,15 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import type { NormalizedTransaction } from "@shared/types";
+import type { DocumentAITelemetry, NormalizedTransaction } from "@shared/types";
+import type { IngestionSource } from "@/lib/ingestionClient";
 import { RefreshCw } from "lucide-react";
 
 export interface IngestionDebugData {
-  source: "documentai" | "unavailable" | "error";
+  source: IngestionSource;
   normalizedTransactions: NormalizedTransaction[];
+  docAiTelemetry?: DocumentAITelemetry;
+  fallbackReason?: string;
 }
 
 export interface DebugPanelProps {
@@ -32,39 +35,48 @@ export interface DebugPanelProps {
  * Only shown when DEBUG_VIEW=true in environment variables.
  */
 export default function DebugPanel({ ingestionData, onRetry }: DebugPanelProps) {
-  const { source, normalizedTransactions } = ingestionData;
+  const { source, normalizedTransactions, docAiTelemetry, fallbackReason } = ingestionData;
   
   // Show first 10 transactions
   const previewTransactions = normalizedTransactions.slice(0, 10);
   const hasMore = normalizedTransactions.length > 10;
 
   // Determine source badge label and variant
-  const sourceLabel = source === "documentai" 
-    ? "DOC AI PATH" 
-    : source === "unavailable" 
-    ? "FALLBACK PATH" 
+  const sourceLabel = source === "documentai"
+    ? "DOC AI PATH"
+    : source === "legacy"
+    ? "FALLBACK PATH"
     : "ERROR";
-  
-  const sourceVariant = source === "documentai" 
-    ? "default" 
-    : source === "unavailable" 
-    ? "secondary" 
+
+  const sourceVariant = source === "documentai"
+    ? "default"
+    : source === "legacy"
+    ? "secondary"
     : "destructive";
+
+  const telemetryItems = docAiTelemetry
+    ? [
+        { label: "Enabled", value: docAiTelemetry.enabled ? "Yes" : "No" },
+        { label: "Processor", value: docAiTelemetry.processor ?? "—" },
+        { label: "Latency", value: docAiTelemetry.latencyMs != null ? `${docAiTelemetry.latencyMs} ms` : "—" },
+        { label: "Entities", value: docAiTelemetry.entityCount },
+      ]
+    : [];
 
   return (
     <div className="rounded-xl border border-dashed border-border/70 bg-card/50 p-4 space-y-4">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <div>
-            <div className="text-sm font-semibold text-foreground">Ingestion Debug Panel</div>
-            <p className="text-xs text-muted-foreground mt-1">
-              Raw normalized transactions and ingestion source for troubleshooting.
-            </p>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <div>
+              <div className="text-sm font-semibold text-foreground">Ingestion Debug Panel</div>
+              <p className="text-xs text-muted-foreground mt-1">
+                Raw normalized transactions and ingestion source for troubleshooting.
+              </p>
+            </div>
+            <Badge variant={sourceVariant} className="uppercase tracking-wide">
+              {sourceLabel}
+            </Badge>
           </div>
-          <Badge variant={sourceVariant} className="uppercase tracking-wide">
-            {sourceLabel}
-          </Badge>
-        </div>
         <Button 
           variant="outline" 
           size="sm" 
@@ -75,6 +87,32 @@ export default function DebugPanel({ ingestionData, onRetry }: DebugPanelProps) 
           Retry
         </Button>
       </div>
+
+      {(docAiTelemetry || fallbackReason) && (
+        <div className="rounded-lg border border-border/60 bg-background/70 p-4 space-y-3">
+          <div className="flex items-center justify-between">
+            <div className="text-xs font-medium text-foreground">DocAI Execution Telemetry</div>
+            {fallbackReason && (
+              <Badge variant="secondary" className="text-[10px] uppercase tracking-wide">
+                Fallback: {fallbackReason}
+              </Badge>
+            )}
+          </div>
+
+          {telemetryItems.length > 0 ? (
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+              {telemetryItems.map(item => (
+                <div key={item.label} className="rounded-md border border-border/50 bg-card/70 p-3">
+                  <div className="text-[11px] uppercase text-muted-foreground tracking-wide">{item.label}</div>
+                  <div className="text-sm font-semibold text-foreground mt-1">{item.value}</div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="text-xs text-muted-foreground">No DocAI telemetry available.</div>
+          )}
+        </div>
+      )}
 
       <div className="rounded-lg border border-border/60 bg-background/70 overflow-hidden">
         <div className="px-4 py-3 border-b border-border/60 bg-background/80">

--- a/server/_core/documentAIClient.ts
+++ b/server/_core/documentAIClient.ts
@@ -1,6 +1,7 @@
 import { DocumentProcessorServiceClient } from "@google-cloud/documentai";
 import { DocumentAiNormalizedDocument, normalizeDocumentAITransactions } from "@shared/normalization";
 import type { CanonicalDocument } from "@shared/transactions";
+import type { DocumentAITelemetry } from "@shared/types";
 import { DocumentAiProcessorType, getDocumentAiConfig } from "./env";
 
 let cachedClient: DocumentProcessorServiceClient | null = null;
@@ -14,23 +15,47 @@ export function getDocumentAiClient(): DocumentProcessorServiceClient | null {
   return cachedClient;
 }
 
+export interface DocumentAiProcessResult {
+  document: CanonicalDocument | null;
+  telemetry: DocumentAITelemetry;
+}
+
 export async function processWithDocumentAI(
   fileBuffer: Buffer,
   documentType: CanonicalDocument["documentType"]
-): Promise<CanonicalDocument | null> {
+): Promise<DocumentAiProcessResult> {
   const config = getDocumentAiConfig();
   if (!config.enabled || !config.ready || !config.credentials) {
     if (config.enabled && !config.ready) {
       console.warn("Document AI enabled but missing configuration", { missing: config.missing });
     }
-    return null;
+    return {
+      document: null,
+      telemetry: {
+        enabled: config.enabled,
+        processor: null,
+        latencyMs: null,
+        entityCount: 0,
+      },
+    } satisfies DocumentAiProcessResult;
   }
 
   const client = getDocumentAiClient();
   const processorId = resolveProcessorId(config, mapDocTypeToProcessor(documentType));
-  if (!client || !processorId) return null;
+  if (!client || !processorId) {
+    return {
+      document: null,
+      telemetry: {
+        enabled: config.enabled,
+        processor: processorId ?? null,
+        latencyMs: null,
+        entityCount: 0,
+      },
+    } satisfies DocumentAiProcessResult;
+  }
 
   const name = buildProcessorName(config.projectId, config.location, processorId);
+  const start = Date.now();
 
   try {
     const [result] = await client.processDocument({
@@ -71,15 +96,34 @@ export async function processWithDocumentAI(
 
     const transactions = normalizeDocumentAITransactions(normalizedDoc, documentType);
 
+    const latencyMs = Date.now() - start;
+    const entityCount = result.document?.entities?.length ?? 0;
+
     return {
-      documentType,
-      transactions,
-      rawText: normalizedDoc.text,
-      warnings: transactions.length === 0 ? ["No transactions returned from Document AI"] : undefined,
-    } satisfies CanonicalDocument;
+      document: {
+        documentType,
+        transactions,
+        rawText: normalizedDoc.text,
+        warnings: transactions.length === 0 ? ["No transactions returned from Document AI"] : undefined,
+      } satisfies CanonicalDocument,
+      telemetry: {
+        enabled: config.enabled,
+        processor: processorId,
+        latencyMs,
+        entityCount,
+      },
+    } satisfies DocumentAiProcessResult;
   } catch (error) {
     console.error("Document AI processing failed", error);
-    return null;
+    return {
+      document: null,
+      telemetry: {
+        enabled: config.enabled,
+        processor: processorId,
+        latencyMs: Date.now() - start,
+        entityCount: 0,
+      },
+    } satisfies DocumentAiProcessResult;
   }
 }
 

--- a/server/ingestRoutes.ts
+++ b/server/ingestRoutes.ts
@@ -5,6 +5,7 @@ import { processWithDocumentAI } from "./_core/documentAIClient";
 import { getDocumentAiConfig } from "./_core/env";
 import { normalizeLegacyTransactions } from "@shared/normalization";
 import type { CanonicalDocument, CanonicalTransaction } from "@shared/transactions";
+import type { DocumentAITelemetry } from "@shared/types";
 
 // Support both JSON and multipart form data
 const upload = multer({ storage: multer.memoryStorage() });
@@ -105,20 +106,39 @@ export function registerIngestionRoutes(app: Express) {
 
     const { fileName, buffer, documentType } = parsed;
 
+    // Track Document AI result so we can safely surface telemetry even when using fallbacks
+    let docAiResult: { document: CanonicalDocument | null; telemetry: DocumentAITelemetry } = {
+      document: null,
+      telemetry: {
+        enabled: false,
+        processor: null,
+        latencyMs: null,
+        entityCount: 0,
+      },
+    };
+
     try {
       // Get config first to check if Document AI is enabled
       const config = getDocumentAiConfig();
       const isDocAIEnabled = config && config.enabled === true;
-      
-      // Try Document AI first (if enabled)
-      const docAIDocument = isDocAIEnabled 
-        ? await processWithDocumentAI(buffer, documentType)
-        : null;
 
-      if (docAIDocument && docAIDocument.transactions.length > 0) {
+      // Try Document AI first (if enabled)
+      docAiResult = isDocAIEnabled
+        ? await processWithDocumentAI(buffer, documentType)
+        : {
+            document: null,
+            telemetry: {
+              enabled: false,
+              processor: null,
+              latencyMs: null,
+              entityCount: 0,
+            } satisfies DocumentAITelemetry,
+          };
+
+      if (docAiResult.document && docAiResult.document.transactions.length > 0) {
         // Document AI succeeded
-        console.log(`[Ingestion] Document AI succeeded for ${fileName}: ${docAIDocument.transactions.length} transactions`);
-        return res.json({ source: "documentai", document: docAIDocument });
+        console.log(`[Ingestion] Document AI succeeded for ${fileName}: ${docAiResult.document.transactions.length} transactions`);
+        return res.json({ source: "documentai", document: docAiResult.document, docAiTelemetry: docAiResult.telemetry });
       }
 
       // Document AI failed or disabled - use legacy fallback
@@ -138,17 +158,24 @@ export function registerIngestionRoutes(app: Express) {
         rawText: undefined,
       };
 
-      return res.json({ 
-        source: "legacy", 
+      return res.json({
+        source: "legacy",
         fallback: fallbackReason,
-        document: legacyDoc 
+        document: legacyDoc,
+        docAiTelemetry: docAiResult.telemetry,
       });
     } catch (error) {
       console.error("Error processing ingestion", { fileName, documentType, error });
-      return res.status(500).json({ 
-        error: "Failed to ingest document", 
+      return res.status(500).json({
+        error: "Failed to ingest document",
         fallback: "legacy",
-        source: "error"
+        source: "error",
+        docAiTelemetry: {
+          enabled: false,
+          processor: null,
+          latencyMs: null,
+          entityCount: 0,
+        } satisfies DocumentAITelemetry,
       });
     }
   });

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -51,4 +51,14 @@ export interface NormalizedTransaction {
   metadata?: Record<string, any>;
 }
 
+export interface DocumentAITelemetry {
+  enabled: boolean;
+  processor: string | null;
+  latencyMs: number | null;
+  entityCount: number;
+}
+
+// Backwards compatibility alias
+export type DocumentAiTelemetry = DocumentAITelemetry;
+
 export * from "./transactions";


### PR DESCRIPTION
## Summary
- adopt the shared DocumentAITelemetry alias and update ingestion result typing to include fallback, telemetry, and export identifiers
- propagate telemetry, fallback reason, and export identifier through the ingestion client and Home page debug state
- keep the Document AI client and ingestion routes aligned with the new telemetry typing

## Testing
- pnpm check


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693665780980832f89f0c1625afe093c)