### PR TITLE
Add export event store and CSV/PDF export endpoints

### DIFF
--- a/server/exportEventStore.ts
+++ b/server/exportEventStore.ts
@@ -1,0 +1,60 @@
+import { randomUUID } from "crypto";
+import type { CanonicalTransaction } from "@shared/transactions";
+
+export type ExportFormat = "csv" | "pdf";
+
+export interface ExportEvent {
+  exportId: string;
+  format: ExportFormat;
+  status: "success" | "expired" | "error";
+  timestamp: Date;
+  message?: string;
+}
+
+interface StoredTransactions {
+  transactions: CanonicalTransaction[];
+  expiresAt: number;
+}
+
+export class ExportEventStore {
+  private readonly transactions = new Map<string, StoredTransactions>();
+  private readonly events: ExportEvent[] = [];
+
+  constructor(private readonly ttlMs = 60 * 60 * 1000) {}
+
+  storeTransactions(transactions: CanonicalTransaction[]): string {
+    const id = randomUUID();
+    const expiresAt = Date.now() + this.ttlMs;
+
+    this.transactions.set(id, { transactions, expiresAt });
+
+    return id;
+  }
+
+  getTransactions(id: string): CanonicalTransaction[] | null {
+    const entry = this.transactions.get(id);
+
+    if (!entry) return null;
+    if (Date.now() > entry.expiresAt) {
+      this.transactions.delete(id);
+      return null;
+    }
+
+    return entry.transactions;
+  }
+
+  logEvent(event: Omit<ExportEvent, "timestamp">): void {
+    this.events.push({ ...event, timestamp: new Date() });
+  }
+
+  getEvents(): ExportEvent[] {
+    return [...this.events];
+  }
+
+  clear(): void {
+    this.transactions.clear();
+    this.events.length = 0;
+  }
+}
+
+export const exportEventStore = new ExportEventStore();

--- a/server/exportRoutes.test.ts
+++ b/server/exportRoutes.test.ts
@@ -1,13 +1,14 @@
 import express from "express";
 import request from "supertest";
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { registerExportRoutes } from "./exportRoutes";
-import { storeTransactions } from "./exportRoutes";
+import { registerExportRoutes, storeTransactions } from "./exportRoutes";
 import type { CanonicalTransaction } from "@shared/transactions";
+import { exportEventStore } from "./exportEventStore";
 
 describe("registerExportRoutes", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    exportEventStore.clear();
   });
 
   it("exports CSV successfully with valid export ID", async () => {
@@ -32,23 +33,31 @@ describe("registerExportRoutes", () => {
     const app = express();
     registerExportRoutes(app);
 
-    const res = await request(app).get(`/api/export/${exportId}`);
+    const res = await request(app).get(`/api/export/${exportId}/csv`);
 
     expect(res.status).toBe(200);
     expect(res.headers["content-type"]).toContain("text/csv");
     expect(res.headers["content-disposition"]).toContain("attachment");
     expect(res.text).toContain("Date,Description,Payee,Debit,Credit,Balance,Memo");
     expect(res.text).toContain("Test Transaction");
+
+    const events = exportEventStore.getEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ exportId, format: "csv", status: "success" });
   });
 
   it("returns 404 for invalid export ID", async () => {
     const app = express();
     registerExportRoutes(app);
 
-    const res = await request(app).get("/api/export/invalid-id");
+    const res = await request(app).get("/api/export/invalid-id/csv");
 
     expect(res.status).toBe(404);
     expect(res.body.error).toBe("Export not found or expired");
+    const events = exportEventStore.getEvents();
+    expect(events).toEqual([
+      expect.objectContaining({ exportId: "invalid-id", format: "csv", status: "expired" }),
+    ]);
   });
 
   it("includes BOM when bom query parameter is true", async () => {
@@ -73,11 +82,46 @@ describe("registerExportRoutes", () => {
     const app = express();
     registerExportRoutes(app);
 
-    const res = await request(app).get(`/api/export/${exportId}?bom=true`);
+    const res = await request(app).get(`/api/export/${exportId}/csv?bom=true`);
 
     expect(res.status).toBe(200);
     // BOM is \uFEFF (UTF-8 BOM)
     expect(res.text.charCodeAt(0)).toBe(0xfeff);
   });
-});
 
+  it("returns stub PDF with appropriate headers", async () => {
+    const sampleTransactions: CanonicalTransaction[] = [
+      {
+        date: "2024-01-05",
+        posted_date: "2024-01-05",
+        description: "PDF Transaction",
+        payee: "Test Payee",
+        debit: 50.0,
+        credit: 0,
+        balance: 950.0,
+        account_id: null,
+        source_bank: null,
+        statement_period: { start: null, end: null },
+        metadata: {},
+      },
+    ];
+
+    const exportId = storeTransactions(sampleTransactions);
+
+    const app = express();
+    registerExportRoutes(app);
+
+    const res = await request(app).get(`/api/export/${exportId}/pdf`);
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toContain("application/pdf");
+    expect(res.headers["content-disposition"]).toContain("attachment");
+    const pdfText = res.text || res.body.toString("utf-8");
+    expect(pdfText).toContain("PDF Export Stub");
+
+    const events = exportEventStore.getEvents();
+    expect(events).toContainEqual(
+      expect.objectContaining({ exportId, format: "pdf", status: "success" }),
+    );
+  });
+});

--- a/server/exportRoutes.ts
+++ b/server/exportRoutes.ts
@@ -1,20 +1,8 @@
-import type { Express } from "express";
-import { randomUUID } from "crypto";
+import type { Express, Response } from "express";
 import { toCSV } from "@shared/export/csv";
 import type { CanonicalTransaction } from "@shared/transactions";
 import type { NormalizedTransaction } from "@shared/types";
-
-// In-memory store for transactions (keyed by UUID)
-// In production, this could be replaced with Redis or a database
-const transactionStore = new Map<string, CanonicalTransaction[]>();
-
-// Clean up old entries after 1 hour
-const STORE_TTL_MS = 60 * 60 * 1000;
-
-function cleanupOldEntries() {
-  // For now, we'll just clear entries older than TTL on access
-  // In production, use a proper TTL mechanism
-}
+import { exportEventStore } from "./exportEventStore";
 
 /**
  * Convert CanonicalTransaction to NormalizedTransaction for CSV export
@@ -26,64 +14,121 @@ function toNormalized(tx: CanonicalTransaction): NormalizedTransaction {
   };
 }
 
-/**
- * Store transactions and return a UUID for retrieval
- */
-export function storeTransactions(transactions: CanonicalTransaction[]): string {
-  const id = randomUUID();
-  transactionStore.set(id, transactions);
-  
-  // Schedule cleanup after TTL
-  setTimeout(() => {
-    transactionStore.delete(id);
-  }, STORE_TTL_MS);
-  
-  return id;
+function buildCsvFilename(): string {
+  const timestamp = new Date().toISOString().split("T")[0];
+  return `bank-transactions-${timestamp}.csv`;
 }
 
-/**
- * Get transactions by ID
- */
+function buildPdfFilename(): string {
+  const timestamp = new Date().toISOString().split("T")[0];
+  return `bank-transactions-${timestamp}.pdf`;
+}
+
+function getTransactionsOr404(id: string, format: "csv" | "pdf") {
+  const transactions = exportEventStore.getTransactions(id);
+
+  if (!transactions || transactions.length === 0) {
+    exportEventStore.logEvent({ exportId: id, format, status: "expired" });
+    return null;
+  }
+
+  return transactions;
+}
+
+function sendCsvExport(
+  res: Response,
+  id: string,
+  transactions: CanonicalTransaction[],
+  includeBOM: boolean,
+) {
+  try {
+    const normalizedTransactions: NormalizedTransaction[] = transactions.map(toNormalized);
+    const csv = toCSV(normalizedTransactions, { includeBOM });
+
+    res.setHeader("Content-Type", "text/csv; charset=utf-8");
+    res.setHeader("Content-Disposition", `attachment; filename="${buildCsvFilename()}"`);
+    res.send(csv);
+
+    exportEventStore.logEvent({ exportId: id, format: "csv", status: "success" });
+  } catch (error) {
+    console.error("Error generating CSV export", error);
+    exportEventStore.logEvent({
+      exportId: id,
+      format: "csv",
+      status: "error",
+      message: error instanceof Error ? error.message : "Unknown error",
+    });
+    res.status(500).json({
+      error: "Failed to generate CSV export",
+      message: error instanceof Error ? error.message : "Unknown error",
+    });
+  }
+}
+
+function buildStubPdf(transactions: CanonicalTransaction[]): Buffer {
+  const summary = `PDF Export Stub\nTransactions: ${transactions.length}`;
+  return Buffer.from(summary, "utf-8");
+}
+
+function sendPdfExport(res: Response, id: string, transactions: CanonicalTransaction[]) {
+  try {
+    const pdfBuffer = buildStubPdf(transactions);
+
+    res.setHeader("Content-Type", "application/pdf");
+    res.setHeader("Content-Disposition", `attachment; filename="${buildPdfFilename()}"`);
+    res.send(pdfBuffer);
+
+    exportEventStore.logEvent({ exportId: id, format: "pdf", status: "success" });
+  } catch (error) {
+    console.error("Error generating PDF export", error);
+    exportEventStore.logEvent({
+      exportId: id,
+      format: "pdf",
+      status: "error",
+      message: error instanceof Error ? error.message : "Unknown error",
+    });
+    res.status(500).json({
+      error: "Failed to generate PDF export",
+      message: error instanceof Error ? error.message : "Unknown error",
+    });
+  }
+}
+
+export function storeTransactions(transactions: CanonicalTransaction[]): string {
+  return exportEventStore.storeTransactions(transactions);
+}
+
 export function getTransactions(id: string): CanonicalTransaction[] | null {
-  cleanupOldEntries();
-  return transactionStore.get(id) ?? null;
+  return exportEventStore.getTransactions(id);
 }
 
 export function registerExportRoutes(app: Express) {
-  /**
-   * GET /api/export/:id
-   * Export transactions as CSV
-   */
-  app.get("/api/export/:id", (req, res) => {
+  app.get("/api/export/:id/csv", (req, res) => {
     const { id } = req.params;
     const includeBOM = req.query.bom === "true" || req.query.bom === "1";
-    
-    const transactions = getTransactions(id);
-    
-    if (!transactions || transactions.length === 0) {
-      return res.status(404).json({ 
+
+    const transactions = getTransactionsOr404(id, "csv");
+    if (!transactions) {
+      return res.status(404).json({
         error: "Export not found or expired",
         message: "The requested export is no longer available. Please regenerate the export.",
       });
     }
 
-    try {
-      // Convert CanonicalTransaction[] to NormalizedTransaction[] for CSV export
-      const normalizedTransactions: NormalizedTransaction[] = transactions.map(toNormalized);
-      const csv = toCSV(normalizedTransactions, { includeBOM });
-      const timestamp = new Date().toISOString().split("T")[0];
-      const filename = `bank-transactions-${timestamp}.csv`;
-      
-      res.setHeader("Content-Type", "text/csv; charset=utf-8");
-      res.setHeader("Content-Disposition", `attachment; filename="${filename}"`);
-      res.send(csv);
-    } catch (error) {
-      console.error("Error generating CSV export", error);
-      res.status(500).json({ 
-        error: "Failed to generate CSV export",
-        message: error instanceof Error ? error.message : "Unknown error",
+    sendCsvExport(res, id, transactions, includeBOM);
+  });
+
+  app.get("/api/export/:id/pdf", (req, res) => {
+    const { id } = req.params;
+    const transactions = getTransactionsOr404(id, "pdf");
+
+    if (!transactions) {
+      return res.status(404).json({
+        error: "Export not found or expired",
+        message: "The requested export is no longer available. Please regenerate the export.",
       });
     }
+
+    sendPdfExport(res, id, transactions);
   });
 }
-


### PR DESCRIPTION
## Summary
- add an ExportEventStore to persist export lookups and log export events
- implement CSV and stub PDF export endpoints that handle expired IDs gracefully
- update export route tests for new endpoints and event logging

## Testing
- pnpm vitest run server/exportRoutes.test.ts


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693715ab21f4832f995df4ff7580352a)