### PR TITLE
Export transaction details enhancement

### DIFF
--- a/shared/transactions.ts
+++ b/shared/transactions.ts
@@ -1,4 +1,4 @@
-import type { NormalizedTransaction } from "./types";
+import type { NormalizedTransaction, TransactionMetadata } from "./types";
 
 export interface CanonicalTransaction {
   /** Customer-visible transaction date (e.g., activity date) */
@@ -24,8 +24,14 @@ export interface CanonicalTransaction {
     start: string | null;
     end: string | null;
   };
+  /** Optional ending balance for the document (or transaction-level if provided) */
+  ending_balance?: number | null;
+
+  /** Optional extracted/enriched description (can differ from raw description) */
+  inferred_description?: string | null;
+
   /** Arbitrary metadata for debugging or downstream enrichment */
-  metadata: Record<string, any>;
+  metadata?: TransactionMetadata;
 }
 
 export interface CanonicalDocument {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -47,8 +47,23 @@ export interface NormalizedTransaction {
     end: string | null;
   };
   
+  /** Optional extracted/enriched description (can differ from raw description) */
+  inferred_description?: string | null;
+
+  /** Optional ending balance for the document (or transaction-level if provided) */
+  ending_balance?: number | null;
+
   /** Additional metadata (e.g., edited flag, parsing source, etc.) */
-  metadata?: Record<string, any>;
+  metadata?: TransactionMetadata;
+}
+
+export interface TransactionMetadata {
+  edited?: boolean;
+  edited_at?: string | null;
+  inferred_description?: string | null;
+
+  // Allow additional metadata keys without losing type-safety for known fields.
+  [key: string]: any;
 }
 
 export interface DocumentAiTelemetry {


### PR DESCRIPTION
Extend CSV export to include transaction edit metadata, inferred description, and calculated ending balances for a more comprehensive data fetch.

---
<a href="https://cursor.com/background-agent?bcId=bc-6ab9adb9-4155-4924-8e21-b738e1159fc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6ab9adb9-4155-4924-8e21-b738e1159fc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Revamps CSV export to include signed amount, edit metadata, inferred description, and computed ending balance, with corresponding type updates, helpers, and tests.
> 
> - **CSV Export (`shared/export/csv.ts`)**:
>   - Redefines headers to: `date`, `description`, `amount`, `balance`, `metadata_edited`, `metadata_edited_at`, `ending_balance`, `inferred_description`.
>   - Outputs signed `amount` (credit − debit), ISO `date`, and coerces nulls to empty strings; escapes cells.
>   - Computes `ending_balance` for the final row when not explicitly provided; supports explicit per-record `ending_balance`.
>   - Derives `inferred_description` from `record.inferred_description` → `metadata.inferred_description` → `description`.
>   - Adds helpers: `formatNumber`, `formatISODate`, `formatString`, `formatBoolean`, `getSignedAmount`, `inferStartingBalance`, `formatEndingBalance`, `toFiniteNumber`.
> - **Types (`shared/types.ts`, `shared/transactions.ts`)**:
>   - Adds `inferred_description?`, `ending_balance?` to `NormalizedTransaction` and `CanonicalTransaction`.
>   - Introduces `TransactionMetadata` with `edited?`, `edited_at?`, `inferred_description?`; uses in `metadata?`.
>   - Adds utilities: `markEdited`, `isEdited`, `toCanonical`.
> - **Tests**:
>   - `shared/export/csv.test.ts`: Update expectations to new schema, signed amounts, metadata fields, and computed `ending_balance`.
>   - `server/exportRoutes.test.ts`: Validate new CSV header/rows and increased `transactionCount` in metrics (3).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 160d729339f52eced0f92f7eb02d732c7beba4c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->