### PR TITLE
Database url file handling

### DIFF
--- a/server/_core/env.test.ts
+++ b/server/_core/env.test.ts
@@ -1,11 +1,55 @@
-import { describe, expect, it } from "vitest";
-import { ENV, getDocumentAiConfig } from "./env";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { describe, expect, it, vi } from "vitest";
+
+async function importFreshEnv(overrides: Record<string, string | undefined>) {
+  vi.resetModules();
+  const prev = { ...process.env };
+
+  for (const [k, v] of Object.entries(overrides)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+
+  const mod = await import("./env");
+
+  // Restore env for isolation (module keeps its own snapshot).
+  for (const key of Object.keys(process.env)) delete process.env[key];
+  Object.assign(process.env, prev);
+
+  return mod;
+}
 
 describe("getDocumentAiConfig", () => {
-  it("disables Document AI when not configured", () => {
+  it("disables Document AI when not configured", async () => {
+    const { ENV, getDocumentAiConfig } = await importFreshEnv({});
     const config = getDocumentAiConfig();
     expect(config.enabled).toBe(ENV.enableDocAi);
     expect(config.ready).toBe(false);
     expect(config.missing.length).toBeGreaterThan(0);
+  });
+});
+
+describe("DATABASE_URL resolution", () => {
+  it("prefers DATABASE_URL when set", async () => {
+    const { ENV } = await importFreshEnv({
+      DATABASE_URL: "mysql://user:pass@host:3306/db",
+      DATABASE_URL_FILE: "/should/not/be/read",
+    });
+    expect(ENV.databaseUrl).toBe("mysql://user:pass@host:3306/db");
+  });
+
+  it("falls back to DATABASE_URL_FILE when DATABASE_URL is unset", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "dburl-"));
+    const filePath = path.join(dir, "DATABASE_URL");
+    fs.writeFileSync(filePath, "mysql://user:pass@host:3306/db\n", "utf8");
+
+    const { ENV } = await importFreshEnv({
+      DATABASE_URL: undefined,
+      DATABASE_URL_FILE: filePath,
+    });
+
+    expect(ENV.databaseUrl).toBe("mysql://user:pass@host:3306/db");
   });
 });

--- a/server/db.ts
+++ b/server/db.ts
@@ -1,15 +1,15 @@
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/mysql2";
 import { InsertUser, users } from "../drizzle/schema";
-import { ENV } from './_core/env';
+import { ENV } from "./_core/env";
 
 let _db: ReturnType<typeof drizzle> | null = null;
 
 // Lazily create the drizzle instance so local tooling can run without a DB.
 export async function getDb() {
-  if (!_db && process.env.DATABASE_URL) {
+  if (!_db && ENV.databaseUrl) {
     try {
-      _db = drizzle(process.env.DATABASE_URL);
+      _db = drizzle(ENV.databaseUrl);
     } catch (error) {
       console.warn("[Database] Failed to connect:", error);
       _db = null;


### PR DESCRIPTION
Honor `DATABASE_URL_FILE` when initializing the DB client to support Cloud Run Secret Manager deployments.

---
<a href="https://cursor.com/background-agent?bcId=bc-713336ed-c946-45e7-b206-4c3f4518dd47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-713336ed-c946-45e7-b206-4c3f4518dd47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

