### PR TITLE
feat: Deployment status UI for Cloud Run (#30)

### DIFF
--- a/client/src/components/AdminStatusPanel.tsx
+++ b/client/src/components/AdminStatusPanel.tsx
@@ -1,0 +1,144 @@
+import { useQuery } from "@tanstack/react-query";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { 
+  Server, 
+  Clock, 
+  GitBranch, 
+  Cpu,
+  CheckCircle2,
+  XCircle
+} from "lucide-react";
+
+interface StatusResponse {
+  deployedRevision: string;
+  serviceName: string;
+  buildId: string;
+  timestamp: string;
+  documentAiEnabled: boolean;
+  version: string;
+  nodeEnv: string;
+  uptimeSeconds: number;
+}
+
+function formatUptime(seconds: number): string {
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  if (hours > 0) {
+    return `${hours}h ${minutes}m`;
+  }
+  return `${minutes}m`;
+}
+
+export function AdminStatusPanel() {
+  const { data: status, isLoading, error } = useQuery<StatusResponse>({
+    queryKey: ["status"],
+    queryFn: async () => {
+      const res = await fetch("/api/status");
+      if (!res.ok) throw new Error("Failed to fetch status");
+      return res.json();
+    },
+    refetchInterval: 30000, // Refresh every 30s
+  });
+
+  if (isLoading) {
+    return (
+      <Card className="w-full max-w-md">
+        <CardContent className="p-4">
+          <div className="animate-pulse space-y-2">
+            <div className="h-4 bg-muted rounded w-3/4"></div>
+            <div className="h-4 bg-muted rounded w-1/2"></div>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (error || !status) {
+    return (
+      <Card className="w-full max-w-md border-destructive">
+        <CardContent className="p-4">
+          <p className="text-destructive text-sm">Failed to load status</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const isProduction = status.nodeEnv === "production";
+  const isCloudRun = status.deployedRevision !== "local";
+
+  return (
+    <Card className="w-full max-w-md">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm font-medium flex items-center gap-2">
+          <Server className="h-4 w-4" />
+          Deployment Status
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {/* Environment Badge */}
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-muted-foreground">Environment</span>
+          <Badge variant={isProduction ? "default" : "secondary"}>
+            {status.nodeEnv}
+          </Badge>
+        </div>
+
+        {/* Revision */}
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-muted-foreground flex items-center gap-1">
+            <GitBranch className="h-3 w-3" />
+            Revision
+          </span>
+          <code className="text-xs bg-muted px-2 py-1 rounded">
+            {status.deployedRevision}
+          </code>
+        </div>
+
+        {/* Version */}
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-muted-foreground">Version</span>
+          <span className="text-sm">{status.version}</span>
+        </div>
+
+        {/* Document AI Status */}
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-muted-foreground flex items-center gap-1">
+            <Cpu className="h-3 w-3" />
+            Document AI
+          </span>
+          {status.documentAiEnabled ? (
+            <Badge variant="default" className="bg-green-600">
+              <CheckCircle2 className="h-3 w-3" />
+              Enabled
+            </Badge>
+          ) : (
+            <Badge variant="secondary">
+              <XCircle className="h-3 w-3" />
+              Disabled
+            </Badge>
+          )}
+        </div>
+
+        {/* Uptime */}
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-muted-foreground flex items-center gap-1">
+            <Clock className="h-3 w-3" />
+            Uptime
+          </span>
+          <span className="text-sm">{formatUptime(status.uptimeSeconds)}</span>
+        </div>
+
+        {/* Cloud Run indicator */}
+        {isCloudRun && (
+          <div className="pt-2 border-t">
+            <p className="text-xs text-muted-foreground">
+              Running on Cloud Run • {status.serviceName}
+            </p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -18,9 +18,10 @@ import { ingestWithDocumentAI, type IngestionSource } from "@/lib/ingestionClien
 import { toCSV } from "@shared/export/csv";
 import type { CanonicalTransaction } from "@shared/transactions";
 import type { DocumentAiTelemetry, IngestionFailure } from "@shared/types";
-import { Download, Eye, FileText, Loader2 } from "lucide-react";
+import { Download, Eye, FileText, Loader2, Settings } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
+import { AdminStatusPanel } from "@/components/AdminStatusPanel";
 
 // Check if debug view is enabled via environment variable
 // Supports both VITE_DEBUG_VIEW (Vite convention) and DEBUG_VIEW (as specified in requirements)
@@ -40,6 +41,7 @@ export default function Home() {
   const [fallbackReason, setFallbackReason] = useState<string | undefined>(undefined);
   const [showPreviewModal, setShowPreviewModal] = useState(false);
   const [exportId, setExportId] = useState<string | undefined>();
+  const [showAdminPanel, setShowAdminPanel] = useState(false);
   
   // Cache files for retry functionality
   const fileCache = useRef<Map<string, File>>(new Map());
@@ -324,18 +326,28 @@ export default function Home() {
         {/* Header */}
         <header className="border-b border-border/50 backdrop-blur-md bg-background/30">
           <div className="container mx-auto px-6 py-6">
-            <div className="flex items-center gap-3">
-              <div className="p-2 rounded-lg bg-primary/10">
-                <FileText className="w-6 h-6 text-primary" />
+            <div className="flex items-center justify-between gap-3">
+              <div className="flex items-center gap-3">
+                <div className="p-2 rounded-lg bg-primary/10">
+                  <FileText className="w-6 h-6 text-primary" />
+                </div>
+                <div>
+                  <h1 className="text-2xl font-bold text-foreground">
+                    Bank Statement Parser
+                  </h1>
+                  <p className="text-sm text-muted-foreground">
+                    Extract transactions from PDF statements for QuickBooks reconciliation
+                  </p>
+                </div>
               </div>
-              <div>
-                <h1 className="text-2xl font-bold text-foreground">
-                  Bank Statement Parser
-                </h1>
-                <p className="text-sm text-muted-foreground">
-                  Extract transactions from PDF statements for QuickBooks reconciliation
-                </p>
-              </div>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => setShowAdminPanel(!showAdminPanel)}
+                title="Deployment Status"
+              >
+                <Settings className="h-4 w-4" />
+              </Button>
             </div>
           </div>
         </header>
@@ -559,6 +571,13 @@ export default function Home() {
         source={ingestionSource}
         processedFiles={processedFiles}
       />
+
+      {/* Admin Status Panel */}
+      {showAdminPanel && (
+        <div className="fixed bottom-4 right-4 z-50">
+          <AdminStatusPanel />
+        </div>
+      )}
     </div>
   );
 }

--- a/server/ingestRoutes.test.ts
+++ b/server/ingestRoutes.test.ts
@@ -268,4 +268,33 @@ describe("registerIngestionRoutes", () => {
       expect(res.body.results[1].year).toBeDefined();
     });
   });
+
+  describe("GET /api/status", () => {
+    it("should return deployment status", async () => {
+      const app = express();
+      app.use(express.json());
+      registerIngestionRoutes(app);
+
+      const response = await request(app).get("/api/status");
+      
+      expect(response.status).toBe(200);
+      expect(response.body).toHaveProperty("deployedRevision");
+      expect(response.body).toHaveProperty("timestamp");
+      expect(response.body).toHaveProperty("documentAiEnabled");
+      expect(response.body).toHaveProperty("version");
+      expect(response.body).toHaveProperty("uptimeSeconds");
+      expect(typeof response.body.uptimeSeconds).toBe("number");
+    });
+
+    it("should indicate local development when not on Cloud Run", async () => {
+      const app = express();
+      app.use(express.json());
+      registerIngestionRoutes(app);
+
+      const response = await request(app).get("/api/status");
+      
+      // In test environment, K_REVISION is not set
+      expect(response.body.deployedRevision).toBe("local");
+    });
+  });
 });

--- a/server/ingestRoutes.ts
+++ b/server/ingestRoutes.ts
@@ -143,6 +143,30 @@ function extractYear(fileName: string): string {
 }
 
 export function registerIngestionRoutes(app: Express) {
+  // Status endpoint for deployment information
+  app.get("/api/status", (req, res) => {
+    const config = getDocumentAiConfig();
+    res.json({
+      // Cloud Run environment variables
+      deployedRevision: process.env.K_REVISION || "local",
+      serviceName: process.env.K_SERVICE || "dev",
+      
+      // Build info
+      buildId: process.env.BUILD_ID || process.env.K_REVISION?.split("-").pop() || "unknown",
+      timestamp: new Date().toISOString(),
+      
+      // Feature flags
+      documentAiEnabled: config && config.enabled === true,
+      
+      // App info
+      version: process.env.npm_package_version || "1.0.0",
+      nodeEnv: process.env.NODE_ENV || "development",
+      
+      // Uptime
+      uptimeSeconds: Math.floor(process.uptime()),
+    });
+  });
+
   // Support both multipart and JSON
   app.post("/api/ingest", upload.single("file"), async (req, res) => {
     const parsed = parseRequest(req);


### PR DESCRIPTION
## Description

This PR adds a deployment status UI panel that exposes Cloud Run build/deploy state for debugging and confirming version in production.

## Changes

- **Added `/api/status` endpoint** (`server/ingestRoutes.ts`)
  - Returns Cloud Run environment variables (`K_REVISION`, `K_SERVICE`)
  - Includes build info, feature flags (Document AI status), app version, and uptime
  - Lightweight and safe to expose publicly

- **Created `AdminStatusPanel` component** (`client/src/components/AdminStatusPanel.tsx`)
  - React Query-powered component with auto-refresh every 30 seconds
  - Displays environment, revision, version, Document AI status, and uptime
  - Shows Cloud Run indicator when deployed

- **Added toggle button to Home page** (`client/src/pages/Home.tsx`)
  - Settings icon in header toggles the admin panel
  - Panel appears in bottom-right corner when enabled

- **Added tests** (`server/ingestRoutes.test.ts`)
  - Verifies status endpoint returns expected fields
  - Tests local development detection

## Verification

- ✅ `pnpm check` passes (types verified)
- ✅ Tests pass
- ✅ Panel auto-refreshes every 30 seconds
- ✅ Shows "local" for development, actual revision in Cloud Run
- ✅ Document AI status helps debug parsing issues

Related to #114

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a `/api/status` endpoint and an AdminStatusPanel UI toggled from Home to display deployment and Document AI status.
> 
> - **Backend**:
>   - **Status API**: Add `GET /api/status` in `server/ingestRoutes.ts` returning `deployedRevision`, `serviceName`, `buildId`, `timestamp`, `documentAiEnabled`, `version`, `nodeEnv`, and `uptimeSeconds`.
>   - **Tests**: Extend `server/ingestRoutes.test.ts` to verify response fields and local dev behavior.
> - **Frontend**:
>   - **Admin panel**: Introduce `AdminStatusPanel` (`client/src/components/AdminStatusPanel.tsx`) with 30s auto-refresh showing environment, revision, version, Document AI status, uptime, and Cloud Run indicator.
>   - **Home integration**: Add header `Settings` toggle and render the panel in `client/src/pages/Home.tsx` (bottom-right overlay).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a2f9493dd577f58a7659423f492e05fb9ce87b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->