### PR TITLE
Github bug verification

### DIFF
--- a/server/exportRoutes.ts
+++ b/server/exportRoutes.ts
@@ -12,6 +12,7 @@ import { getAccounts, checkImportExists, storeImportLog, getImportLogs } from ".
 import { verifySessionToken } from "./middleware/auth";
 import { parse as parseCookie } from "cookie";
 import { COOKIE_NAME } from "@shared/const";
+import { normalizeDateString } from "@shared/normalization";
 
 // In-memory store for transactions (keyed by UUID)
 // In production, this could be replaced with Redis or a database
@@ -30,10 +31,6 @@ const CLEANUP_INTERVAL_MS = 10 * 60 * 1000;
 
 const SHEETS_TRANSACTIONS_SHEET_TITLE = "Transactions";
 const SHEETS_HASHES_SHEET_TITLE = "Transaction Hashes";
-
-// Pattern for extracting YYYY-MM from ISO date format (YYYY-MM-DD)
-// Intentionally uses partial matching to extract period from full date
-const PERIOD_PATTERN = /^(\d{4}-\d{2})/;
 
 function toSheetsRow(tx: CanonicalTransaction): string[] {
   // Spec #129 Columns:
@@ -552,15 +549,40 @@ export function registerExportRoutes(app: Express): void {
       // Group transactions by period once for better performance
       const transactionsByPeriod = new Map<string, number>();
       for (const tx of transactions) {
-        const txDate = tx.date ?? tx.posted_date;
-        if (!txDate) continue;
-        
-        // Extract YYYY-MM from ISO date format (YYYY-MM-DD)
-        const periodMatch = txDate.match(PERIOD_PATTERN);
-        const txPeriod = periodMatch?.[1];
-        if (!txPeriod) continue;
-        
-        transactionsByPeriod.set(txPeriod, (transactionsByPeriod.get(txPeriod) || 0) + 1);
+        // Prefer actual transaction dates, normalize various formats, and handle empty strings.
+        const candidateDates = [tx.date, tx.posted_date].filter(
+          (d) => typeof d === "string" && d.trim().length > 0
+        ) as string[];
+
+        let normalizedDate: string | null = null;
+        for (const d of candidateDates) {
+          const n = normalizeDateString(d, year);
+          if (n) {
+            normalizedDate = n;
+            break;
+          }
+        }
+
+        let txPeriod: string | null = null;
+        if (normalizedDate) {
+          // YYYY-MM from YYYY-MM-DD
+          txPeriod = normalizedDate.slice(0, 7);
+        } else {
+          // Fall back to statement metadata if transaction dates are missing or unparseable
+          const startNorm = normalizeDateString(tx.statement_period?.start ?? null, year);
+          const endNorm = normalizeDateString(tx.statement_period?.end ?? null, year);
+          const sp = startNorm ?? endNorm;
+          if (sp) {
+            txPeriod = sp.slice(0, 7);
+          } else if (Array.isArray(statement_periods) && statement_periods.length === 1) {
+            // Last-resort: if this sync call targets a single period, attribute unknown-date rows to that period
+            txPeriod = statement_periods[0];
+          }
+        }
+
+        if (txPeriod) {
+          transactionsByPeriod.set(txPeriod, (transactionsByPeriod.get(txPeriod) || 0) + 1);
+        }
       }
 
       for (let i = 0; i < statement_periods.length; i++) {


### PR DESCRIPTION
Improve transaction period attribution by normalizing dates and implementing robust fallbacks for missing or malformed dates.

Previously, transactions with empty, non-ISO, or missing dates were skipped when calculating per-period totals, leading to undercounting. The `tx.date ?? tx.posted_date` fallback also failed for empty strings. This PR fixes that by ensuring a period is always derived if possible, using `normalizeDateString` and multiple fallback options.

---
<a href="https://cursor.com/background-agent?bcId=bc-8f0e8372-ccf8-4e10-99ba-eb77e90d8493"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8f0e8372-ccf8-4e10-99ba-eb77e90d8493"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances transaction period attribution during Sheets sync to prevent undercounting when dates are empty or non‑ISO.
> 
> - Uses `normalizeDateString` to parse `tx.date`/`tx.posted_date`; handles empty strings and mixed formats
> - Falls back to `tx.statement_period.start/end`, and finally to the single requested `statement_period` when needed
> - Replaces fragile regex-based `YYYY-MM` extraction with normalized date slicing
> - Updates per-period transaction tally in `server/exportRoutes.ts` accordingly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7885458a0c8b4bfebba21e784823ec19fe5a6d6c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->